### PR TITLE
Add SciPy 2026 reviewer entry to news

### DIFF
--- a/_data/news.yaml
+++ b/_data/news.yaml
@@ -6,6 +6,10 @@
 
 - year: 2026
   year-extra: July
+  description: Reviewer at <a href="https://www.scipy2026.scipy.org/"> SciPy 2026 </a>
+
+- year: 2026
+  year-extra: July
   description: Reviewer at  <a href="https://2026.midl.io/"> Medical Imaging with Deep Learning (MIDL 2026) </a>
 
 - year: 2026


### PR DESCRIPTION
## Summary
- Adds a new news entry for Reviewer at SciPy 2026 (July 2026)

## Test plan
- [ ] Verify the news entry renders correctly on the CV page
- [ ] Confirm the link to SciPy 2026 works


Made with [Cursor](https://cursor.com)